### PR TITLE
fix(deploy.yml): upgrade runner from ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
       - main
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [18]


### PR DESCRIPTION
## Summary
- `ubuntu-20.04` hosted runners are deprecated by GitHub — jobs were stuck indefinitely on "Waiting for a runner to pick up this job..."
- Switched to `ubuntu-latest` (currently maps to `ubuntu-24.04`) so the workflow picks up a runner immediately and stays forward-compatible

## Test plan
- [ ] Merge and verify the next push to `main` triggers a workflow run that advances past the runner-assignment step
- [ ] Confirm the site deploys successfully to GitHub Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)