### PR TITLE
feat: floating pill header/footer, theme fix, and animation sync

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,24 +1,20 @@
 import { FC } from "react";
-import { Grid, Button, IconButton } from "@mui/material";
-import Box from "@mui/material/Box";
+import { Box, Button, IconButton, useTheme } from "@mui/material";
 import BottomNavigation from "@mui/material/BottomNavigation";
 import BottomNavigationAction from "@mui/material/BottomNavigationAction";
 import SchoolIcon from "@mui/icons-material/School";
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
 import ComputerIcon from "@mui/icons-material/Computer";
 import MovingIcon from "@mui/icons-material/Moving";
-import React from "react";
-import { useNavigate } from "react-router-dom";
-import { useTheme } from "@mui/material";
 import GitHubIcon from "@mui/icons-material/GitHub";
 import LinkedInIcon from "@mui/icons-material/LinkedIn";
 import DownloadIcon from "@mui/icons-material/Download";
 import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
+import React from "react";
+import { useNavigate } from "react-router-dom";
 import resume from "../../assets/pdf/CV STEFANO RAMIREZ.pdf";
 
-interface FooterProps {}
-
-const Footer: FC<FooterProps> = () => {
+const Footer: FC = () => {
   const style = useTheme();
   const [value, setValue] = React.useState<number>();
   const navigate = useNavigate();
@@ -26,196 +22,149 @@ const Footer: FC<FooterProps> = () => {
   const handleChange = (_event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
     switch (newValue) {
-      case 0:
-        navigate("/education");
-        break;
-      case 1:
-        navigate("/experience/");
-        break;
-      case 2:
-        navigate("/portfolio/");
-        break;
-      case 3:
-        navigate("/skills/");
-        break;
-      default:
-        break;
+      case 0: navigate("/education"); break;
+      case 1: navigate("/experience/"); break;
+      case 2: navigate("/portfolio/"); break;
+      case 3: navigate("/skills/"); break;
     }
   };
 
+  const pillButtonSx = {
+    px: 2,
+    py: 0.75,
+    borderRadius: "20px",
+    fontSize: "0.8rem",
+    color: "rgba(255,255,255,0.8)",
+    border: "1px solid rgba(255,255,255,0.15)",
+    transition: "all 0.2s ease",
+    "&:hover": {
+      backgroundColor: `${style.palette.primary.main}22`,
+      color: style.palette.primary.main,
+      border: `1px solid ${style.palette.primary.main}66`,
+    },
+  };
+
+  const glassIconButtonSx = {
+    color: "rgba(255,255,255,0.7)",
+    width: 36,
+    height: 36,
+    border: "1px solid rgba(255,255,255,0.12)",
+    backgroundColor: "rgba(255,255,255,0.06)",
+    "&:hover": {
+      backgroundColor: `${style.palette.primary.main}22`,
+      color: style.palette.primary.main,
+      border: `1px solid ${style.palette.primary.main}66`,
+    },
+  };
+
   return (
-    <>
-      <Grid
+    <Box
+      sx={{
+        position: "fixed",
+        bottom: "12px",
+        left: "12px",
+        right: "12px",
+        zIndex: 1100,
+        borderRadius: { xs: "24px", md: "50px" },
+        background: "rgba(10, 10, 10, 0.65)",
+        backdropFilter: "blur(20px)",
+        WebkitBackdropFilter: "blur(20px)",
+        boxShadow: "0 -4px 32px rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255,0.08)",
+      }}
+    >
+      {/* Desktop */}
+      <Box
         sx={{
-          display: "grid",
-          gridAutoFlow: "column",
-          gridTemplateColumns: "1fr, 1fr",
-          justifyContent: "space-around",
-          bottom: 0,
-          width: "100dvw",
-          height: "12vh",
-          backgroundColor: style.palette.background.paper,
-          borderTopRightRadius: 15,
-          borderTopLeftRadius: 15,
-          padding: 0,
-          position: "fixed",
-          border: `2px solid ${style.palette.primary.main}`,
+          display: { xs: "none", md: "flex" },
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 1.5,
+          py: 1,
+          px: 2,
         }}
       >
-        <IconButton
-          aria-label="linkedIn Button Mobile"
-          onClick={() => {
-            window.location.href =
-              "https://www.linkedin.com/in/stefano-ramirez-novello/";
-          }}
-          sx={{
-            display: {
-              xs: "grid",
-              sm: "grid",
-              md: "none",
-              lg: "none",
-              xl: "none",
-            },
-            marginBottom: 50,
-            color: style.palette.text.secondary,
-          }}
-        >
-          <LinkedInIcon />
-        </IconButton>
-        <IconButton
-          aria-label="linkedIn Button Mobile"
-          onClick={() => {
-            window.open(resume, "_blank");
-          }}
-          sx={{
-            display: {
-              xs: "grid",
-              sm: "grid",
-              md: "none",
-              lg: "none",
-              xl: "none",
-            },
-            color: style.palette.text.secondary,
-            marginBottom: 50,
-          }}
-        >
-          <PictureAsPdfIcon />
-        </IconButton>
-        <IconButton
-          sx={{
-            display: {
-              xs: "grid",
-              sm: "grid",
-              md: "none",
-              lg: "none",
-              xl: "none",
-            },
-            color: style.palette.text.secondary,
-            marginBottom: 50,
-          }}
-          onClick={() => {
-            window.location.href = "https://github.com/ramirezStefano/";
-          }}
-        >
-          <GitHubIcon sx={{ justifySelf: "center" }} />
-        </IconButton>
         <Button
-          variant="contained"
-          color="primary"
-          onClick={() => {
-            window.location.href =
-              "https://www.linkedin.com/in/stefano-ramirez-novello/";
-          }}
-          sx={{
-            display: {
-              xs: "none",
-              sm: "none",
-              md: "grid",
-              lg: "grid",
-              xl: "grid",
-            },
-            maxHeight: 36,
-            minHeight: 10,
-            alignSelf: "center",
-            gridAutoFlow: "column",
-          }}
+          startIcon={<LinkedInIcon fontSize="small" />}
+          sx={pillButtonSx}
+          onClick={() => window.open("https://www.linkedin.com/in/stefano-ramirez-novello/", "_blank")}
         >
-          <LinkedInIcon />
-          Contact me!
+          LinkedIn
         </Button>
         <Button
-          variant="contained"
-          color="primary"
-          sx={{
-            display: {
-              xs: "none",
-              sm: "none",
-              md: "grid",
-              lg: "grid",
-              xl: "grid",
-            },
-            maxHeight: 36,
-            minHeight: 10,
-            alignSelf: "center",
-            gridAutoFlow: "column",
-          }}
-          onClick={() => {
-            window.open(resume, "_blank");
-          }}
+          startIcon={<DownloadIcon fontSize="small" />}
+          sx={pillButtonSx}
+          onClick={() => window.open(resume, "_blank")}
         >
-          <DownloadIcon />
-          Download Resume
+          Resume
         </Button>
         <Button
-          variant="contained"
-          color="primary"
-          sx={{
-            display: {
-              xs: "none",
-              sm: "none",
-              md: "grid",
-              lg: "grid",
-              xl: "grid",
-            },
-            maxHeight: 36,
-            minHeight: 10,
-            alignSelf: "center",
-            gridAutoFlow: "column",
-          }}
-          onClick={() => {
-            window.location.href = "https://github.com/ramirezStefano/";
-          }}
+          startIcon={<GitHubIcon fontSize="small" />}
+          sx={pillButtonSx}
+          onClick={() => window.open("https://github.com/ramirezStefano/", "_blank")}
         >
-          <GitHubIcon sx={{ marginRight: 1 }} />
-          Follow me!
+          GitHub
         </Button>
+      </Box>
+
+      {/* Mobile */}
+      <Box sx={{ display: { xs: "block", md: "none" } }}>
         <Box
           sx={{
-            position: "fixed",
-            bottom: 0,
-            left: 0,
-            right: 0,
-            display: {
-              xs: "grid",
-              sm: "grid",
-              md: "none",
-              lg: "none",
-              xl: "none",
+            display: "flex",
+            justifyContent: "center",
+            gap: 1.5,
+            pt: 1.25,
+            pb: 0.5,
+          }}
+        >
+          <IconButton
+            aria-label="LinkedIn"
+            sx={glassIconButtonSx}
+            onClick={() => window.open("https://www.linkedin.com/in/stefano-ramirez-novello/", "_blank")}
+          >
+            <LinkedInIcon fontSize="small" />
+          </IconButton>
+          <IconButton
+            aria-label="Download resume"
+            sx={glassIconButtonSx}
+            onClick={() => window.open(resume, "_blank")}
+          >
+            <PictureAsPdfIcon fontSize="small" />
+          </IconButton>
+          <IconButton
+            aria-label="GitHub"
+            sx={glassIconButtonSx}
+            onClick={() => window.open("https://github.com/ramirezStefano/", "_blank")}
+          >
+            <GitHubIcon fontSize="small" />
+          </IconButton>
+        </Box>
+
+        <BottomNavigation
+          value={value}
+          onChange={handleChange}
+          sx={{
+            background: "transparent",
+            borderRadius: "0 0 24px 24px",
+            "& .MuiBottomNavigationAction-root": {
+              color: "rgba(255,255,255,0.5)",
+              minWidth: 0,
+            },
+            "& .Mui-selected": {
+              color: style.palette.primary.main,
+            },
+            "& .MuiBottomNavigationAction-label": {
+              fontSize: "0.65rem",
             },
           }}
         >
-          <BottomNavigation value={value} onChange={handleChange}>
-            <BottomNavigationAction label="Education" icon={<SchoolIcon />} />
-            <BottomNavigationAction label="Experience" icon={<MovingIcon />} />
-            <BottomNavigationAction
-              label="Portfolio"
-              icon={<AccountTreeIcon />}
-            />
-            <BottomNavigationAction label="Skills" icon={<ComputerIcon />} />
-          </BottomNavigation>
-        </Box>
-      </Grid>
-    </>
+          <BottomNavigationAction label="Education" icon={<SchoolIcon fontSize="small" />} />
+          <BottomNavigationAction label="Experience" icon={<MovingIcon fontSize="small" />} />
+          <BottomNavigationAction label="Portfolio" icon={<AccountTreeIcon fontSize="small" />} />
+          <BottomNavigationAction label="Skills" icon={<ComputerIcon fontSize="small" />} />
+        </BottomNavigation>
+      </Box>
+    </Box>
   );
 };
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,8 +4,9 @@ import Box from "@mui/material/Box";
 import Toolbar from "@mui/material/Toolbar";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import {
+  Divider,
   Drawer,
   IconButton,
   List,
@@ -28,6 +29,7 @@ const pages = ["Education", "Experience", "Skills", "Portfolio"];
 
 const Header: FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const style = useTheme();
   const isMobile = useMediaQuery(style.breakpoints.down("md"));
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -37,95 +39,223 @@ const Header: FC = () => {
     setDrawerOpen(false);
   };
 
+  const isActive = (page: string) =>
+    location.pathname.toLowerCase().includes(page.toLowerCase());
+
+  const logoFilter = `invert(1) sepia(1) saturate(5) hue-rotate(${calculateHueRotate(style.palette.primary.main)}deg)`;
+
   return (
     <AppBar
       position="fixed"
+      elevation={0}
       sx={{
-        background: "rgba(0, 0, 0, 0.5)",
-        backdropFilter: "blur(10px)",
-        boxShadow: "0 4px 6px rgba(0, 0, 0, 0.5)",
+        top: "12px",
+        left: "12px",
+        right: "12px",
+        width: "auto",
+        borderRadius: "50px",
+        background: "rgba(10, 10, 10, 0.65)",
+        backdropFilter: "blur(20px)",
+        WebkitBackdropFilter: "blur(20px)",
+        boxShadow: "0 8px 32px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.08)",
       }}
     >
-      <Toolbar disableGutters sx={{ px: 1, justifyContent: "space-between" }}>
-        <Box sx={{ display: "flex", alignItems: "center" }}>
+      <Toolbar
+        disableGutters
+        sx={{ px: 2, justifyContent: "space-between", minHeight: "56px !important" }}
+      >
+        {/* Logo + wordmark */}
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
           <img
             className="animateRotation"
             aria-label="logo"
             src={logo}
             style={{
               display: "block",
-              margin: 10,
-              width: isMobile ? "40px" : "60px",
-              filter: `invert(1) sepia(1) saturate(5) hue-rotate(${calculateHueRotate(style.palette.primary.main)}deg)`,
+              width: isMobile ? "32px" : "42px",
+              filter: logoFilter,
             }}
           />
           <Typography
-            variant={isMobile ? "h6" : "h5"}
-            component="a"
+            component="span"
             sx={{
               fontFamily: "monospace",
               fontWeight: 700,
-              letterSpacing: ".3rem",
-              textDecoration: "none",
+              fontSize: isMobile ? "0.85rem" : "1rem",
+              letterSpacing: ".25rem",
+              color: "white",
+              whiteSpace: "nowrap",
+              display: "flex",
+              alignItems: "center",
+              lineHeight: 1,
+              mb: 0,
             }}
           >
-            <Link style={{ color: style.palette.text.primary }} to="/">
+            <Link style={{ color: "inherit", textDecoration: "none" }} to="/">
               RAMIREZ STEFANO
             </Link>
           </Typography>
         </Box>
 
+        {/* Right side */}
         <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-          <Box sx={{ display: { xs: "none", md: "flex" } }}>
+          {/* Desktop nav */}
+          <Box sx={{ display: { xs: "none", md: "flex" }, alignItems: "center", gap: 0.5 }}>
             {pages.map((page) => (
               <Button
                 key={page}
                 onClick={() => handleNavClick(`/${page.toLowerCase()}/`)}
-                sx={{ my: 2, mx: 1 }}
-                variant="contained"
+                sx={{
+                  px: 2,
+                  py: 0.75,
+                  borderRadius: "20px",
+                  fontSize: "0.8rem",
+                  fontWeight: isActive(page) ? 700 : 400,
+                  color: isActive(page) ? style.palette.primary.main : "rgba(255,255,255,0.8)",
+                  backgroundColor: isActive(page)
+                    ? `${style.palette.primary.main}22`
+                    : "transparent",
+                  border: isActive(page)
+                    ? `1px solid ${style.palette.primary.main}66`
+                    : "1px solid transparent",
+                  transition: "all 0.2s ease",
+                  "&:hover": {
+                    backgroundColor: `${style.palette.primary.main}22`,
+                    color: style.palette.primary.main,
+                    border: `1px solid ${style.palette.primary.main}66`,
+                  },
+                }}
               >
                 {page}
               </Button>
             ))}
           </Box>
 
-          <Paper sx={{ display: "flex" }}>
+          {/* Theme controls */}
+          <Paper
+            elevation={0}
+            sx={{
+              display: "flex",
+              borderRadius: "20px",
+              background: "rgba(255,255,255,0.08)",
+              border: "1px solid rgba(255,255,255,0.1)",
+            }}
+          >
             <DarkModeSwitch />
             <ThemeColorShuffle />
           </Paper>
 
+          {/* Mobile hamburger */}
           <IconButton
             color="inherit"
             aria-label="open navigation menu"
             onClick={() => setDrawerOpen(true)}
-            sx={{ display: { xs: "flex", md: "none" } }}
+            sx={{
+              display: { xs: "flex", md: "none" },
+              width: 36,
+              height: 36,
+              backgroundColor: "rgba(255,255,255,0.08)",
+              border: "1px solid rgba(255,255,255,0.1)",
+              "&:hover": { backgroundColor: "rgba(255,255,255,0.16)" },
+            }}
           >
-            <MenuIcon />
+            <MenuIcon fontSize="small" />
           </IconButton>
         </Box>
       </Toolbar>
 
+      {/* Mobile drawer */}
       <Drawer
         anchor="right"
         open={drawerOpen}
         onClose={() => setDrawerOpen(false)}
-        PaperProps={{ sx: { width: 220 } }}
+        PaperProps={{
+          sx: {
+            width: 240,
+            background: "rgba(12, 12, 12, 0.95)",
+            backdropFilter: "blur(20px)",
+            borderLeft: "1px solid rgba(255,255,255,0.08)",
+          },
+        }}
       >
-        <Box sx={{ display: "flex", justifyContent: "flex-end", p: 1 }}>
-          <IconButton onClick={() => setDrawerOpen(false)} aria-label="close menu">
-            <CloseIcon />
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            px: 2,
+            py: 1.5,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <img src={logo} width={26} style={{ filter: logoFilter }} alt="logo" />
+            <Typography
+              sx={{
+                fontFamily: "monospace",
+                fontWeight: 700,
+                fontSize: "0.7rem",
+                letterSpacing: "0.2rem",
+                color: "rgba(255,255,255,0.6)",
+              }}
+            >
+              MENU
+            </Typography>
+          </Box>
+          <IconButton
+            onClick={() => setDrawerOpen(false)}
+            aria-label="close menu"
+            sx={{ color: "rgba(255,255,255,0.6)" }}
+          >
+            <CloseIcon fontSize="small" />
           </IconButton>
         </Box>
-        <List>
+
+        <Divider sx={{ borderColor: "rgba(255,255,255,0.08)" }} />
+
+        <List sx={{ pt: 1 }}>
           <ListItem disablePadding>
-            <ListItemButton onClick={() => handleNavClick("/")}>
-              <ListItemText primary="Home" />
+            <ListItemButton
+              onClick={() => handleNavClick("/")}
+              sx={{
+                mx: 1,
+                borderRadius: "12px",
+                "&:hover": { backgroundColor: `${style.palette.primary.main}22` },
+              }}
+            >
+              <ListItemText
+                primary="Home"
+                primaryTypographyProps={{
+                  sx: { color: "rgba(255,255,255,0.8)", fontSize: "0.95rem" },
+                }}
+              />
             </ListItemButton>
           </ListItem>
+
           {pages.map((page) => (
             <ListItem key={page} disablePadding>
-              <ListItemButton onClick={() => handleNavClick(`/${page.toLowerCase()}/`)}>
-                <ListItemText primary={page} />
+              <ListItemButton
+                onClick={() => handleNavClick(`/${page.toLowerCase()}/`)}
+                sx={{
+                  mx: 1,
+                  borderRadius: "12px",
+                  backgroundColor: isActive(page)
+                    ? `${style.palette.primary.main}22`
+                    : "transparent",
+                  "&:hover": { backgroundColor: `${style.palette.primary.main}22` },
+                }}
+              >
+                <ListItemText
+                  primary={page}
+                  primaryTypographyProps={{
+                    sx: {
+                      color: isActive(page)
+                        ? style.palette.primary.main
+                        : "rgba(255,255,255,0.8)",
+                      fontWeight: isActive(page) ? 700 : 400,
+                      fontSize: "0.95rem",
+                    },
+                  }}
+                />
               </ListItemButton>
             </ListItem>
           ))}
@@ -134,4 +264,5 @@ const Header: FC = () => {
     </AppBar>
   );
 };
+
 export { Header };

--- a/src/components/routes/Education/Education.tsx
+++ b/src/components/routes/Education/Education.tsx
@@ -53,7 +53,7 @@ const Education: FC = () => {
         <Typography className="animate delay-1" variant="h4" gutterBottom sx={{ mb: 3 }}>
           Education
         </Typography>
-        <Box className="parallax-education" sx={{ mb: 4 }} />
+        <Box className="animate delay-2 parallax-education" sx={{ mb: 4 }} />
 
         <Box>
           {entries.map((entry, i) => (

--- a/src/components/routes/Experience/Experience.tsx
+++ b/src/components/routes/Experience/Experience.tsx
@@ -74,7 +74,7 @@ const Experience: FC = () => {
         <Typography className="animate delay-1" variant="h4" gutterBottom sx={{ mb: 3 }}>
           Experience
         </Typography>
-        <Box className="parallax-experience" sx={{ mb: 4 }} />
+        <Box className="animate delay-2 parallax-experience" sx={{ mb: 4 }} />
 
         <Box>
           {experiences.map((exp, i) => (

--- a/src/components/routes/Portfolio/Portfolio.tsx
+++ b/src/components/routes/Portfolio/Portfolio.tsx
@@ -199,7 +199,7 @@ const Portfolio: FC = () => {
         <Typography className="animate delay-1" variant="h4" gutterBottom sx={{ mb: 3 }}>
           Portfolio
         </Typography>
-        <Box className="parallax-portfolio" sx={{ mb: 4 }} />
+        <Box className="animate delay-2 parallax-portfolio" sx={{ mb: 4 }} />
 
         <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
           {projects.map((project, i) => (

--- a/src/components/routes/Skills/Skills.tsx
+++ b/src/components/routes/Skills/Skills.tsx
@@ -43,7 +43,7 @@ const Skills: FC = () => {
         <Typography className="animate delay-1" variant="h4" gutterBottom sx={{ mb: 3 }}>
           Skills
         </Typography>
-        <Box className="parallax-skills" sx={{ mb: 4 }} />
+        <Box className="animate delay-2 parallax-skills" sx={{ mb: 4 }} />
 
         <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
           {skillGroups.map((group, i) => (

--- a/src/theme/MyThemeProvider.tsx
+++ b/src/theme/MyThemeProvider.tsx
@@ -45,14 +45,14 @@ export default function MyThemeProvider(props: MyThemeProviderProps) {
         ...(ThemeColors[theme][mode] as ThemeOptions),
         typography: {
           h3: {
-            color: ThemeColors[theme][mode].palette.primary?.main,
+            color: mode === "dark" ? "rgba(255,255,255,0.87)" : "rgba(0,0,0,0.87)",
             fontSize: "2rem",
             fontWeight: "bold",
             textTransform: "uppercase",
             letterSpacing: "1px",
           },
           h4: {
-            color: ThemeColors[theme][mode].palette.primary?.main,
+            color: mode === "dark" ? "rgba(255,255,255,0.87)" : "rgba(0,0,0,0.87)",
             fontSize: "2rem",
             fontWeight: "bold",
             textTransform: "uppercase",


### PR DESCRIPTION
## Summary
- **Header**: replaced flat AppBar with a floating pill (dark glass, `borderRadius: 50px`, 12px margins). Nav buttons are pill-shaped with active route highlighting via `useLocation`. Theme controls and hamburger button share the same glass treatment. Wordmark vertically centered with logo (`lineHeight: 1`, `mb: 0`)
- **Footer**: same floating pill language — desktop shows ghost pill buttons for LinkedIn/Resume/GitHub; mobile combines social icon buttons + transparent BottomNavigation in one pill container, removing the old two-layer fixed positioning hack
- **Theme**: `h3`/`h4` colors changed from `primary.main` to high-contrast neutrals (`rgba(255,255,255,0.87)` dark / `rgba(0,0,0,0.87)` light) — fixes headings blending into the gradient background
- **Route parallax images**: added `animate delay-2` class so images fade in in sync with content cards instead of appearing immediately

## Test plan
- [ ] Header floats correctly on all screen sizes; pill shape visible against page background
- [ ] Active route button is highlighted when navigating between pages
- [ ] Mobile drawer opens/closes and highlights active route
- [ ] Footer pill renders at bottom on desktop and mobile
- [ ] Mobile footer: social icons row + BottomNavigation tabs all visible inside pill
- [ ] h3/h4 headings readable on all 4 theme color presets in both light and dark mode
- [ ] Parallax images on Experience/Skills/Education/Portfolio fade in with the cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)